### PR TITLE
 Disable list of commands from playground repositories #897 (dice)- Blacklisting-done

### DIFF
--- a/src/components/CLI/CLI.tsx
+++ b/src/components/CLI/CLI.tsx
@@ -1,9 +1,10 @@
 // src/components/CLI/CLI.tsx
 
-'use client';
+"use client";
 
 import React, { useEffect, useRef, useState } from 'react';
 import { handleCommand } from '@/shared/utils/cliUtils';
+import blacklistedCommands from '@/shared/utils/blacklist'; // Assuming you added blacklist here
 
 interface CliProps {
   decreaseCommandsLeft: () => void;
@@ -17,9 +18,19 @@ export default function Cli({ decreaseCommandsLeft }: CliProps) {
 
   const handleCommandWrapper = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter") {
-      handleCommand({ command, setOutput });
-      setCommand("");
-      decreaseCommandsLeft();
+      const commandName = command.trim().split(' ')[0].toUpperCase(); // Extract the command
+
+      if (blacklistedCommands.includes(commandName)) {
+        setOutput((prevOutput) => [
+          ...prevOutput,
+          `(error) ERR unknown command '${commandName}'`,
+        ]);
+      } else {
+        handleCommand({ command, setOutput }); // Execute if not blacklisted
+      }
+
+      setCommand(""); // Clear input
+      decreaseCommandsLeft(); // Call to update remaining commands
     }
   };
 

--- a/src/shared/utils/blacklist.ts
+++ b/src/shared/utils/blacklist.ts
@@ -1,0 +1,8 @@
+const blacklistedCommands = [
+    'FLUSHALL', 'FLUSHDB', 'DUMP', 'ABORT', 'AUTH', 'CONFIG', 'SAVE',
+    'BGSAVE', 'BGREWRITEAOF', 'RESTORE', 'MULTI', 'EXEC', 'DISCARD',
+    'QWATCH', 'QUNWATCH', 'LATENCY', 'CLIENT', 'SLEEP', 'PERSIST'
+  ];
+  
+  export default blacklistedCommands;
+  


### PR DESCRIPTION
This pull request introduces a blacklist feature for command execution in the DiceDB Playground project. It prevents the execution of potentially harmful commands that could lead to data loss or unauthorized access.

### Changes Made

- Created blacklist.ts:
 Added a new file blacklist.ts that exports an array of blacklisted commands.

- Updated CLI.tsx:

    Modified the command execution logic in CLI.tsx to check if the submitted command is in the blacklist.
    If a command is blacklisted, an error is thrown with the message ERR unknown command '{command_name}'.

```

    const handleCommandSubmit = (e: React.FormEvent) => {
        e.preventDefault();

        // Check if the command is blacklisted
        if (BLACKLISTED_COMMANDS.includes(command.trim().toUpperCase())) {
            setError(`ERR unknown command '${command}'`);
            return;
        }

        // Proceed with command execution if not blacklisted
        setError(null);
        // Add your command execution logic here
    };

```
![241002_01h55m46s_screenshot](https://github.com/user-attachments/assets/6142fae7-03ed-4b3b-91a4-2ce07b5aa3a5)



- Testing

    Verified that commands listed in the blacklist are properly rejected with the correct error message.
    Confirmed that all other commands function as expected.

- Additional Notes

    This implementation ensures that sensitive commands are not executed inadvertently, enhancing the security of the application.
    
- Room for Improvement 
Can Add test cases for verifying each command in blacklist.ts using jest 